### PR TITLE
Tune alert thresholds and annotations in payments.yaml based on recent findings and recommendations

### DIFF
--- a/alerts/payments.yaml
+++ b/alerts/payments.yaml
@@ -3,25 +3,25 @@ groups:
   rules:
   - alert: CriticalPaymentsAlert
     expr: |
-      rate(payment_errors_total[10m]) / rate(payment_requests_total[10m]) > 0.0005 or
-      rate(duplicate_payments_total[15m]) > 3
-    for: 15m
+      rate(payment_errors_total[10m]) / rate(payment_requests_total[10m]) > 0.0004 or
+      rate(duplicate_payments_total[15m]) > 5
+    for: 10m
     labels: { severity: critical }
     annotations: {
       summary: "Critical payment issues detected",
       description: "High payment error rate or duplicate payment transactions detected. Immediate investigation required.",
       runbook: "https://example.com/runbook/payment-errors",
       contact: "On-call Engineer: Rachel Torres (racheltorres@example.com)",
-      escalation: "If not resolved in 15 minutes, escalate to the payment processing manager."
+      escalation: "If not resolved in 10 minutes, escalate to the payment processing manager."
     }
 
   - alert: PaymentLatencyAlert
-    expr: avg_over_time(payment_latency_seconds[5m]) > 2  # Alert if average latency exceeds 2 seconds
+    expr: avg_over_time(payment_latency_seconds[5m]) > 1.5  # Alert if average latency exceeds 1.5 seconds
     for: 5m
     labels: { severity: warning }
     annotations: {
       summary: "High payment latency detected",
-      description: "The average payment latency exceeds 2 seconds. Please investigate potential bottlenecks in the payment processing pipeline.",
+      description: "The average payment latency exceeds 1.5 seconds. Please investigate potential bottlenecks in the payment processing pipeline.",
       runbook: "https://example.com/runbook/payment-latency",
       contact: "On-call Engineer: Rachel Torres (racheltorres@example.com)",
       escalation: "If not resolved in 5 minutes, escalate to the payment processing manager."


### PR DESCRIPTION
This PR tunes the alert thresholds and annotations in payments.yaml for the payments-core group. Changes include:
- Lowered threshold for payment_errors_total rate from 0.0005 to 0.0004
- Increased threshold for duplicate_payments_total rate from 3 to 5
- Reduced alert duration for CriticalPaymentsAlert from 15m to 10m
- Lowered payment latency threshold from 2 seconds to 1.5 seconds
- Updated escalation timing for CriticalPaymentsAlert from 15m to 10m

These changes are based on recent incident review findings and aim to improve alert sensitivity and response.

Please review and merge if acceptable.