### PR TITLE
Further tuning of payment alert thresholds and durations based on operational needs and incident INC-2025-1109 findings

### DIFF
--- a/alerts/payments.yaml
+++ b/alerts/payments.yaml
@@ -2,7 +2,7 @@ groups:
 - name: payments-core
   rules:
   - alert: WarningPaymentErrorRateAlert
-    expr: rate(payment_errors_total[10m]) / rate(payment_requests_total[10m]) > 0.00035
+    expr: rate(payment_errors_total[10m]) / rate(payment_requests_total[10m]) > 0.0003
     for: 5m
     labels:
       severity: warning
@@ -10,23 +10,23 @@ groups:
       service: payment-processing
     annotations: {
       summary: "Elevated payment error rate detected",
-      description: "The payment error rate has exceeded 0.00035 for 5 minutes. Please investigate potential issues before escalation. This tuning is based on recent incident INC-2025-1109 and subsequent recommendations.",
+      description: "The payment error rate has exceeded 0.0003 for 5 minutes. Please investigate potential issues before escalation. This tuning is based on recent incident INC-2025-1109 and subsequent recommendations.",
       runbook: "https://corrected-runbook-url.com/payment-errors",
       contact: "On-call Engineer: Rachel Torres (racheltorres@example.com)",
       escalation: "If not resolved in 5 minutes, escalate to the payment processing manager.",
-      recovery: "Alert resolved when payment error rate returns below 0.00035."
+      recovery: "Alert resolved when payment error rate returns below 0.0003."
     }
 
   - alert: CriticalPaymentErrorRateAlert
     expr: rate(payment_errors_total[5m]) / rate(payment_requests_total[5m]) > 0.0008
-    for: 3m
+    for: 2m
     labels:
       severity: critical
       team: payments
       service: payment-processing
     annotations: {
       summary: "Critical payment error rate detected",
-      description: "The payment error rate has exceeded 0.0008 for 3 minutes. Immediate investigation required. This adjustment follows recent incident INC-2025-1109 and expert tuning recommendations.",
+      description: "The payment error rate has exceeded 0.0008 for 2 minutes. Immediate investigation required. This adjustment follows recent incident INC-2025-1109 and expert tuning recommendations.",
       runbook: "https://corrected-runbook-url.com/payment-errors-critical",
       contact: "On-call Engineer: Rachel Torres (racheltorres@example.com)",
       escalation: "If not resolved in 3 minutes, escalate to the payment processing manager.",
@@ -36,8 +36,8 @@ groups:
   - alert: CriticalPaymentsAlert
     expr: |
       rate(payment_errors_total[10m]) / rate(payment_requests_total[10m]) > 0.0003 or
-      rate(duplicate_payments_total[15m]) > 4
-    for: 12m
+      rate(duplicate_payments_total[15m]) > 3
+    for: 10m
     labels: 
       severity: critical
       team: payments
@@ -52,19 +52,19 @@ groups:
     }
 
   - alert: PaymentLatencyAlert
-    expr: avg_over_time(payment_latency_seconds[5m]) > 1.3  # Adjusted threshold to 1.3 seconds for earlier detection
-    for: 3m
+    expr: avg_over_time(payment_latency_seconds[5m]) > 1.2  # Adjusted threshold to 1.2 seconds for earlier detection
+    for: 2m
     labels: 
       severity: warning
       team: payments
       service: payment-processing
     annotations: {
       summary: "High payment latency detected",
-      description: "The average payment latency exceeds 1.3 seconds. Please investigate potential bottlenecks in the payment processing pipeline. Tuning based on incident INC-2025-1109 review.",
+      description: "The average payment latency exceeds 1.2 seconds. Please investigate potential bottlenecks in the payment processing pipeline. Tuning based on incident INC-2025-1109 review.",
       runbook: "https://corrected-runbook-url.com/payment-latency",
       contact: "On-call Engineer: Rachel Torres (racheltorres@example.com)",
       escalation: "If not resolved in 3 minutes, escalate to the payment processing manager.",
-      recovery: "Alert resolved when average payment latency returns below 1.3 seconds."
+      recovery: "Alert resolved when average payment latency returns below 1.2 seconds."
     }
 
 # Note: Thresholds tuned based on recent incident INC-2025-1109 and expert recommendations.


### PR DESCRIPTION
This pull request proposes additional tuning adjustments to the payment alert thresholds and durations for improved alert sensitivity based on operational needs and lessons learned from incident INC-2025-1109.

Changes include:
- Lowering the WarningPaymentErrorRateAlert threshold from 0.00035 to 0.0003.
- Reducing the CriticalPaymentErrorRateAlert duration from 3 minutes to 2 minutes.
- Decreasing the duplicate payments threshold in CriticalPaymentsAlert from 4 to 3 and reducing alert duration from 12 minutes to 10 minutes.
- Lowering the PaymentLatencyAlert threshold from 1.3 seconds to 1.2 seconds and reducing duration from 3 minutes to 2 minutes.

These changes aim to enhance early detection and response while balancing false positive rates.

Please review and provide feedback or approve for merging.