### PR TITLE
Update dashboard title to 90s rap album style

### DIFF
--- a/dashboards/payments-core-resource-usage.json
+++ b/dashboards/payments-core-resource-usage.json
@@ -141,7 +141,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Payments Core Resource Usage",
+  "title": "Core Beats: Resource Rhythms",
   "uid": "payments-core-resource-usage",
   "version": 1
 }


### PR DESCRIPTION
Changed the dashboard title in dashboards/payments-core-resource-usage.json to "Core Beats: Resource Rhythms" to fit the 90s rap album title style as requested.